### PR TITLE
Fix Bazel 7 support

### DIFF
--- a/julia/private/format.bzl
+++ b/julia/private/format.bzl
@@ -93,10 +93,10 @@ def _julia_format_test_impl(ctx):
 
     # Curate values for the common implementation
     # Use the runner's main source file as srcs
-    curated_srcs = [ctx.file._runner_main]
+    curated_srcs = [ctx.file._test_runner_main]
 
     # Include the runner binary as a dependency
-    curated_deps = [ctx.attr._runner]
+    curated_deps = [ctx.attr._test_runner]
 
     # Include args_file, config, and target srcs as data
     curated_data_files = [args_file, ctx.file.config] + srcs
@@ -115,7 +115,7 @@ def _julia_format_test_impl(ctx):
         data_files = curated_data_files,
         data_targets = curated_data_targets,
         env = curated_env,
-        main = ctx.file._runner_main,
+        main = ctx.file._test_runner_main,
     )
 
 julia_format_test = rule(
@@ -140,13 +140,13 @@ julia_format_test = rule(
             default = Label("//julia/private:entrypoint.jl"),
             allow_single_file = True,
         ),
-        "_runner": attr.label(
+        "_test_runner": attr.label(
             doc = "The format checker binary.",
             cfg = "target",
             providers = [JuliaInfo],
             default = Label("//julia/private/format:format_checker"),
         ),
-        "_runner_main": attr.label(
+        "_test_runner_main": attr.label(
             doc = "The runner's main source file.",
             allow_single_file = [".jl"],
             default = Label("//julia/private/format:src/format_checker.jl"),


### PR DESCRIPTION
For some reason aspects cannot share attribute names with rules they run on. Or so it would seem for Bazel 7.

```
rules_julia % USE_BAZEL_VERSION=7.x bazel test //...
```
```
INFO: Analyzed 83 targets (34 packages loaded, 319 targets configured).
INFO: From Linking external/protobuf~/src/google/protobuf/io/libio_win32.a [for tool]:
warning: /Library/Developer/CommandLineTools/usr/bin/libtool: archive library: bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/protobuf~/src/google/protobuf/io/libio_win32.a the table of contents is empty (no object file members in the library define global symbols)
INFO: From Linking external/protobuf~/protoc [for tool]:
ld: warning: ignoring duplicate libraries: '-lm', '-lpthread'
INFO: From Building external/protobuf~/java/core/libcore.jar (43 source files, 1 source jar) [for tool]:
external/protobuf~/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java:28: warning: [dep-ann] deprecated item is not annotated with @Deprecated
public class RepeatedFieldBuilderV3<
       ^
INFO: Found 59 targets and 24 test targets...
INFO: Elapsed time: 427.364s, Critical Path: 426.46s
INFO: 853 processes: 19 internal, 825 darwin-sandbox, 9 worker.
INFO: Build completed successfully, 853 total actions
//julia/private/format/3rdparty:pkg_test                        (cached) PASSED in 28.5s
//julia/private/standalone_compiler/3rdparty:pkg_test           (cached) PASSED in 21.0s
//julia/private/tests/binary:writer_diff_test                   (cached) PASSED in 0.3s
//julia/private/tests/binary_with_lib:writer_diff_test          (cached) PASSED in 0.3s
//julia/private/tests/format:format_binary_test                 (cached) PASSED in 30.7s
//julia/private/tests/format:format_library_test                (cached) PASSED in 31.6s
//julia/private/tests/format:format_test_target_test            (cached) PASSED in 32.8s
//julia/private/tests/format:test_target                        (cached) PASSED in 9.7s
//julia/private/tests/project_toml_aspect/consumer:multi_deps_diff_test (cached) PASSED in 0.5s
//julia/private/tests/project_toml_aspect/test:calc_utils_manifest_toml_diff (cached) PASSED in 10.6s
//julia/private/tests/project_toml_aspect/test:calc_utils_project_toml_diff (cached) PASSED in 10.6s
//julia/private/tests/project_toml_aspect/test:math_utils_manifest_toml_diff (cached) PASSED in 10.6s
//julia/private/tests/project_toml_aspect/test:math_utils_project_toml_diff (cached) PASSED in 10.4s
//julia/private/tests/project_toml_aspect/test:project_toml_path_validation_test (cached) PASSED in 16.0s
//julia/private/tests/project_toml_aspect/test:string_utils_manifest_toml_diff (cached) PASSED in 10.5s
//julia/private/tests/project_toml_aspect/test:string_utils_project_toml_diff (cached) PASSED in 10.2s
//julia/private/tests/test:hash_test                            (cached) PASSED in 16.3s
//julia/private/tests/test_with_lib:writelib_test               (cached) PASSED in 10.2s
//julia/runfiles/tests:runfiles_test                            (cached) PASSED in 12.5s
//tools/bzl_version_test:bzl_version_test                       (cached) PASSED in 9.9s
//julia/private/tests/project_toml_aspect/test:multi_deps_test_manifest_toml_diff PASSED in 11.7s
//julia/private/tests/project_toml_aspect/test:multi_deps_test_project_toml_diff PASSED in 11.3s
//julia/private/tests/standalone_bin:writer_diff_test                    PASSED in 0.2s
//julia/private/tests/standalone_bin_with_lib:writer_diff_test           PASSED in 0.2s

Executed 4 out of 24 tests: 24 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```